### PR TITLE
added purple in colours.rs - improved uptime formatting (adding days,…

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -7,4 +7,5 @@ pub const RED: &str = "\x1b[31m";
 pub const YELLOW: &str = "\x1B[32m";
 pub const MAGENTA: &str = "\x1b[35m";
 pub const YELLOW_BRIGHT: &str = "\x1B[93m";
+pub const PURPLE: &str = "\x1b[35m";
 pub const RESET: &str = "\x1B[0m";

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,33 @@ mod colors;
 mod utils;
 
 use colors::*;
-use std::{env::var, str::from_boxed_utf8_unchecked};
+use std::env::var;
 use systemstat::{Duration, Platform, System};
+
+fn format_uptime(uptime: Duration) -> String {
+   let total_seconds = uptime.as_secs();
+   let days = total_seconds / 86400;
+   let hours = (total_seconds % 86400) / 3600;
+   let minutes = ((total_seconds % 86400) % 3600) / 60;
+   let seconds = ((total_seconds % 86400) % 3600) % 60;
+
+   let mut result = String::new();
+   if days > 0 {
+       result.push_str(&format!("{}d ", days));
+   }
+   if days > 0 || hours > 0 {
+       result.push_str(&format!("{}h ", hours));
+   }
+   if days > 0 || hours > 0 || minutes > 0 {
+       result.push_str(&format!("{}m ", minutes));
+   }
+   if days > 0 || hours > 0 || minutes > 0 || seconds > 0 {
+       result.push_str(&format!("{}s", seconds));
+   }
+
+   result.trim().to_string()
+}
+
 
 fn main() {
     let sys = System::new();
@@ -28,11 +53,11 @@ fn main() {
             whoami::hostname()
         ),
         format!("{CYAN}os {WHITE}  ~ {CYAN}{}{BLUE}", whoami::distro()),
-        format!("{YELLOW}up{WHITE} ~ {YELLOW}{uptime:?}{BLUE}"),
+        format!("{YELLOW}up{WHITE}   ~ {YELLOW}{}{BLUE}", format_uptime(uptime)),
         format!("{GREEN}wm {WHITE}  ~ {GREEN}{wm}{BLUE}"),
         format!("{MAGENTA}term{WHITE} ~ {MAGENTA}{term}{BLUE}"),
         format!("{YELLOW_BRIGHT}sh {WHITE}  ~ {YELLOW_BRIGHT}{shell}{BLUE}"),
-        format!("{RED}● {YELLOW}● {CYAN}● {BLUE}● {WHITE}●"),
+        format!("{RED}● {YELLOW}● {CYAN}● {BLUE}● {PURPLE}● {WHITE}●"),
     ]
     .join("\n");
 


### PR DESCRIPTION
Made a few changes:

- Added a function that converts the uptime into days, hours and minutes (but only when they exceed the threshold of one of the higher units - e.g 59s, then 59m 59s, 23h 59m 59s, etc)
- Added purple in colours.rs 
- Fixed the spacing on the uptime line since the "~" was not aligned with the other lines
- Removed an unused use